### PR TITLE
fix legend colours

### DIFF
--- a/custom-plugins/msupply-worldmap/src/components/Legend.tsx
+++ b/custom-plugins/msupply-worldmap/src/components/Legend.tsx
@@ -1,4 +1,5 @@
-import { FieldConfigSource, Threshold } from '@grafana/data';
+import { FieldConfigSource, Threshold, getColorForTheme } from '@grafana/data';
+import { useTheme } from '@grafana/ui';
 import React from 'react';
 
 const POSITION_CLASSES = {
@@ -15,6 +16,7 @@ interface LegendProps {
 }
 
 export const Legend: React.FC<LegendProps> = ({ fieldConfig, position = 'bottomleft', visible = true }) => {
+  const theme = useTheme();
   const steps = fieldConfig.defaults?.thresholds?.steps || [];
   const positionClass = (position && POSITION_CLASSES[position]) || POSITION_CLASSES.bottomleft;
   const renderLabel = (step: Threshold, index: number) => {
@@ -34,12 +36,13 @@ export const Legend: React.FC<LegendProps> = ({ fieldConfig, position = 'bottoml
     return null;
   }
 
+  console.warn('steps', steps);
   return (
     <div className={positionClass}>
       <div className="info legend leaflet-control">
         {steps.map((step, index) => (
           <div key={`${step.value}_${step.color}`} className="legend-item">
-            <i style={{ background: step.color }} />
+            <i style={{ background: getColorForTheme(step.color, theme) }} />
             {renderLabel(step, index)}
           </div>
         ))}

--- a/custom-plugins/msupply-worldmap/src/components/Legend.tsx
+++ b/custom-plugins/msupply-worldmap/src/components/Legend.tsx
@@ -36,7 +36,6 @@ export const Legend: React.FC<LegendProps> = ({ fieldConfig, position = 'bottoml
     return null;
   }
 
-  console.warn('steps', steps);
   return (
     <div className={positionClass}>
       <div className="info legend leaflet-control">


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #195 

## Description
The value returned by `step.color` is a non standard text colour when the non primary shades are selected ( e.g. 'semi-dark-orange' ) and these do not relate  to web colours, so react won't render the style.

Selecting a main colour, or a hex or RGB value will work.

To fix - am using a grafana API to translate the text colours to actual colours.
